### PR TITLE
Fix bug in validate_ip function

### DIFF
--- a/src/Namshi/Utils/CodeGenerator.php
+++ b/src/Namshi/Utils/CodeGenerator.php
@@ -14,6 +14,8 @@ class CodeGenerator
      */
     public static $max_code_length = 5;
 
+    protected static $dictionary = 'qwertyuiopasdfghjklzxcvbnm1234567890';
+
     /**
      * Generate random code
      *
@@ -25,10 +27,17 @@ class CodeGenerator
      */
     public static function generateRandomCode($length = null)
     {
-        if (empty ($length) || $length < 0 || !is_numeric($length)) {
+        $length = min((int)$length, 40);
+
+        if ($length <= 0) {
             $length = self::$max_code_length;
         }
 
-        return substr(sha1(microtime()), 1, $length);
+        for ($code = '', $maxOffset = strlen(self::$dictionary) - 1; $length--;) {
+            $code .= self::$dictionary[mt_rand(0, $maxOffset)];
+        }
+
+        return $code;
     }
+
 }

--- a/src/Namshi/Utils/Functions.php
+++ b/src/Namshi/Utils/Functions.php
@@ -83,21 +83,19 @@ function arabic_numbers_to_english($string)
  */
 function validate_ip($ip, $validIps)
 {
+    $validIps = (array)$validIps;
+
     if (filter_var($ip, FILTER_VALIDATE_IP)) {
-        if (!is_array($validIps)) {
-            $validIps = [$validIps];
-        }
+        $ip = ip2long($ip);
 
         foreach ($validIps as $validIp) {
             if (is_scalar($validIp)) {
-                $validIpParts = explode('/', $validIp);
-                $subnet         = array_get($validIpParts, '[0]');
-                $bits           = array_get($validIpParts, '[1]', '32');
-                $ip             = ip2long($ip);
-                $subnet         = ip2long($subnet);
-                $mask           = -1 << (32 - $bits);
+                $ipParts = explode('/', $validIp);
+                $subnet  = ip2long($ipParts[0]);
+                $size    = min(isset($ipParts[1]) ? (int)$ipParts[1] : 32, 32);
+                $mask    = (pow(2, $size) - 1) << (32 - $size);
 
-                if (($ip & $mask) === $subnet) {
+                if (($ip & $mask) === ($subnet & $mask)) {
                     return true;
                 }
             }

--- a/tests/Namshi/Utils/Test/FunctionsTest.php
+++ b/tests/Namshi/Utils/Test/FunctionsTest.php
@@ -63,8 +63,8 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
     public function testValidateIpWithValidIpAndArrayOfRanges()
     {
         $valid = validate_ip('192.168.100.110', array(
-            '192.168.100.64/26',
             '10.168.100.64/26',
+            '192.168.100.64/26',
             '15.168.100.64/26'
         ));
 


### PR DESCRIPTION
Fix bug in validate_ip function: it wouldn't work for more than one subnets because `$ip = ip2long($ip);` line was executed on each iteration giving you `false` on the second one
Fix CodeGenerator to rely on more random source than `microtime()` - 40 chars limitation added as a BC because sha1 is limited to 40 chars
