### PR TITLE
Enanchement for array_get and multidimensional arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         ]
     },
     "require": {
-        "symfony/property-access": "~2.2"
+        "symfony/property-access": "2.5.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "c73b6b546186d267308d40d7d79634a7",
+    "hash": "21733b84d2f5594f7848f0adc27cad55",
     "packages": [
         {
             "name": "symfony/property-access",
-            "version": "v2.4.3",
+            "version": "v2.5.6",
             "target-dir": "Symfony/Component/PropertyAccess",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/PropertyAccess.git",
-                "reference": "37fe0c2dc494b47db4b0850e9dcba3a27cc45c0c"
+                "reference": "7dc28de6660a22bbec9ca717d77201c0fdf8c046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/37fe0c2dc494b47db4b0850e9dcba3a27cc45c0c",
-                "reference": "37fe0c2dc494b47db4b0850e9dcba3a27cc45c0c",
+                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/7dc28de6660a22bbec9ca717d77201c0fdf8c046",
+                "reference": "7dc28de6660a22bbec9ca717d77201c0fdf8c046",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +27,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.5-dev"
                 }
             },
             "autoload": {
@@ -40,14 +41,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony PropertyAccess Component",
@@ -63,7 +62,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2014-02-11 15:39:28"
+            "time": "2014-10-22 17:15:20"
         }
     ],
     "packages-dev": [
@@ -484,17 +483,11 @@
             "time": "2014-03-12 18:29:58"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
 }

--- a/src/Namshi/Utils/Functions.php
+++ b/src/Namshi/Utils/Functions.php
@@ -14,12 +14,13 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 function array_get(array $array, $key, $default = null)
 {
-    if ($key === '[]') {
+    $accessor = PropertyAccess::createPropertyAccessor();
+
+    if ($key === '[]' || ! $accessor->isReadable($array, $key)) {
         return $default;
     }
 
-    $accessor = PropertyAccess::createPropertyAccessor();
-    $value    = $accessor->getValue($array, $key);
+    $value = $accessor->getValue($array, $key);
 
     if (empty($value) && !isset($default)) {
         switch (gettype($value)) {

--- a/tests/Namshi/Utils/Test/FunctionsTest.php
+++ b/tests/Namshi/Utils/Test/FunctionsTest.php
@@ -31,6 +31,14 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $englishNumbers);
     }
 
+    public function testArrayGetMultidimensionalArray()
+    {
+        $array = ['foo' => ['bar' => 300]];
+
+        $this->assertEquals(300, array_get($array, '[foo][bar]'));
+        $this->assertEquals(null, array_get($array, '[foo][bar][foo]'));
+    }
+
     public function testArrayGetAndSetValues()
     {
         $array = array(


### PR DESCRIPTION
Adds check on property readability to avoid the 'Expected argument of type "object or array"' exception on multidimensional arrays